### PR TITLE
feat: 알림 수신 희망 시간 설정 기능 구현

### DIFF
--- a/backend/src/main/java/com/spaceme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/spaceme/auth/service/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
                 ProviderType.from(providerType)
         );
 
-        fcmService.subscribeTopic(HOUR_9.name()+DEFAULT, deviceToken);
+        fcmService.subscribeTopic(HOUR_9.name()+"_"+DEFAULT.name(), deviceToken);
         return AccessTokenResponse.of(jwtProvider.createToken(user.getId().toString()));
     }
 

--- a/backend/src/main/java/com/spaceme/auth/service/AuthService.java
+++ b/backend/src/main/java/com/spaceme/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.spaceme.common.AlienConcept.DEFAULT;
+import static com.spaceme.user.domain.NotificationPreference.HOUR_9;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +37,7 @@ public class AuthService {
                 ProviderType.from(providerType)
         );
 
-        fcmService.subscribeTopic(DEFAULT, deviceToken);
+        fcmService.subscribeTopic(HOUR_9.name()+DEFAULT, deviceToken);
         return AccessTokenResponse.of(jwtProvider.createToken(user.getId().toString()));
     }
 

--- a/backend/src/main/java/com/spaceme/chatGPT/service/ChatGPTService.java
+++ b/backend/src/main/java/com/spaceme/chatGPT/service/ChatGPTService.java
@@ -5,7 +5,8 @@ import com.spaceme.chatGPT.dto.request.PlanRequest;
 import com.spaceme.chatGPT.dto.response.*;
 import com.spaceme.common.exception.NotFoundException;
 import com.spaceme.galaxy.service.GalaxyService;
-import com.spaceme.user.domain.User;
+import com.spaceme.user.domain.UserPreference;
+import com.spaceme.user.repository.UserPreferenceRepository;
 import com.spaceme.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,13 +21,14 @@ import java.util.Map;
 public class ChatGPTService {
     private final WebClient webClient;
     private final UserRepository userRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
     private final GalaxyService galaxyService;
 
     public ThreeResponse generateRoadMap(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+        UserPreference userPreference = userPreferenceRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("사용자 설정을 찾을 수 없습니다."));
 
-        String prompt = user.getSpaceGoal() + "을 위한 구체적인 로드맵을 3단계로 제시해줘.\n" +
+        String prompt = userPreference.getSpaceGoal() + "을 위한 구체적인 로드맵을 3단계로 제시해줘.\n" +
                 "로드맵의 예시는 다음과 같아.\n" +
                 "예를 들어 '수능영어 1타강사'라는 목표를 이루기 위한 로드맵은" +
                 "1. 외고 진학\n" +

--- a/backend/src/main/java/com/spaceme/galaxy/service/GalaxyService.java
+++ b/backend/src/main/java/com/spaceme/galaxy/service/GalaxyService.java
@@ -110,8 +110,8 @@ public class GalaxyService {
                 .title(planRequest.title())
                 .galaxyTheme(themeGenerator.getRandomGalaxyTheme())
                 .user(user)
-                .startDate(planRequest.startDate())
-                .endDate(planRequest.endDate())
+                .startDate(LocalDate.parse(planRequest.startDate()))
+                .endDate(LocalDate.parse(planRequest.endDate()))
                 .days(planRequest.days())
                 .build();
     }

--- a/backend/src/main/java/com/spaceme/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/spaceme/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.spaceme.notification.controller;
 
+import com.spaceme.notification.dto.NotificationTestRequest;
 import com.spaceme.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,9 +13,9 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @GetMapping
-    public ResponseEntity<Void> test() {
-        notificationService.sendNotificationDaily();
+    @PostMapping
+    public ResponseEntity<Void> test(@RequestBody NotificationTestRequest request) {
+        notificationService.sendNotification(request.topic(), request.message());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/spaceme/notification/dto/NotificationTestRequest.java
+++ b/backend/src/main/java/com/spaceme/notification/dto/NotificationTestRequest.java
@@ -1,0 +1,7 @@
+package com.spaceme.notification.dto;
+
+public record NotificationTestRequest(
+        String topic,
+        String message
+) {
+}

--- a/backend/src/main/java/com/spaceme/notification/service/FCMService.java
+++ b/backend/src/main/java/com/spaceme/notification/service/FCMService.java
@@ -42,7 +42,7 @@ public class FCMService {
         }
     }
 
-    public void subscribeTopic(AlienConcept topic, String deviceToken) {
+    public void subscribeTopic(String topic, String deviceToken) {
         try {
             firebaseMessaging.subscribeToTopic(List.of(deviceToken), deviceToken);
             log.info("구독 성공 -- TOKEN = {}, TOPIC = {}", deviceToken, topic);
@@ -52,10 +52,10 @@ public class FCMService {
         }
     }
 
-    public void unSubscribeTopic(AlienConcept topic, String deviceToken) {
+    public void unSubscribeTopic(String topic, String deviceToken) {
         try {
-            firebaseMessaging.unsubscribeFromTopic(List.of(deviceToken), topic.name());
-            log.info("구독 취소 성공 -- TOKEN = {}, TOPIC = {}", deviceToken, topic.name());
+            firebaseMessaging.unsubscribeFromTopic(List.of(deviceToken), topic);
+            log.info("구독 취소 성공 -- TOKEN = {}, TOPIC = {}", deviceToken, topic);
         } catch (Exception exception) {
             log.error("구독 취소에 실패 -- {}", exception.getMessage());
             throw new InternalServerException("FCM 설정 과정에서 오류가 발생했습니다.");

--- a/backend/src/main/java/com/spaceme/notification/service/FCMService.java
+++ b/backend/src/main/java/com/spaceme/notification/service/FCMService.java
@@ -3,7 +3,6 @@ package com.spaceme.notification.service;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
-import com.spaceme.common.AlienConcept;
 import com.spaceme.common.exception.InternalServerException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +21,7 @@ public class FCMService {
     private final FirebaseMessaging firebaseMessaging;
 
     @Transactional
-    public void sendPushNotification(AlienConcept alienConcept, String notificationMessage) {
+    public void sendPushNotification(String topic, String notificationMessage) {
         Message message = Message.builder()
                 .setNotification(
                         Notification.builder()
@@ -30,14 +29,14 @@ public class FCMService {
                                 .setBody(notificationMessage)
                                 .build()
                 )
-                .setTopic(alienConcept.name())
+                .setTopic(topic)
                 .build();
 
         try {
             firebaseMessaging.send(message);
-            log.info("FCM 메시지 전송 성공 -- TOPIC = {}", alienConcept.name());
+            log.info("FCM 메시지 전송 성공 -- TOPIC = {}", topic);
         } catch (Exception e) {
-            log.error("FCM 메시지 전송 실패 -- TOPIC = {}, ERROR = {}", alienConcept.name(), e.getMessage());
+            log.error("FCM 메시지 전송 실패 -- TOPIC = {}, ERROR = {}", topic, e.getMessage());
             throw new InternalServerException("FCM 메시지 전송 중 오류가 발생했습니다.");
         }
     }

--- a/backend/src/main/java/com/spaceme/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/spaceme/notification/service/NotificationService.java
@@ -4,36 +4,89 @@ import com.spaceme.common.AlienConcept;
 import com.spaceme.common.exception.NotFoundException;
 import com.spaceme.notification.domain.Notification;
 import com.spaceme.notification.repository.NotificationRepository;
+import com.spaceme.user.domain.NotificationPreference;
+import com.spaceme.user.service.UserService;
+import jakarta.annotation.PostConstruct;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.*;
 import java.util.Arrays;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@Transactional
+@Transactional(readOnly = true)
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(10);
     private final FCMService fcmService;
+    private final UserService userService;
 
-    @Scheduled(cron = "0 0 9 * * ?")
-    public void sendNotificationDaily() {
-        Arrays.stream(AlienConcept.values()).forEach(concept -> {
-            String message = pickRandomMessage(concept);
-            fcmService.sendPushNotification(concept, message);
-        });
+    @PostConstruct
+    public void initializeRepeatingNotifications() {
+        Arrays.stream(NotificationPreference.values())
+                .filter(preference -> preference != NotificationPreference.OFF)
+                .forEach(preference ->
+                        Arrays.stream(AlienConcept.values()).forEach(concept -> {
+                            if (hasSubscribers(preference, concept))
+                                scheduleRepeatingNotification(preference, concept);
+                        })
+                );
     }
 
-    private String pickRandomMessage(AlienConcept topic) {
-        Notification notification = notificationRepository.findRandomMessageByConcept(topic)
+    public void scheduleRepeatingNotification(NotificationPreference preference, AlienConcept concept) {
+        long initialDelay = calculateDelayInSeconds(calculateNextExecutionTime(preference.getHour()));
+        long periodInSeconds = HOURS.toSeconds(24);
+
+        String topic = generateTopic(preference, concept);
+        String message = pickRandomMessage(concept);
+
+        scheduler.scheduleAtFixedRate(() ->
+                sendNotification(topic, message), initialDelay, periodInSeconds, SECONDS
+        );
+    }
+
+    private LocalDateTime calculateNextExecutionTime(int hour) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime nextExecutionTime = now.withHour(hour).withMinute(0).withSecond(0);
+
+        if (nextExecutionTime.isBefore(now))
+            nextExecutionTime = nextExecutionTime.plusDays(1);
+
+        return nextExecutionTime;
+    }
+
+    private long calculateDelayInSeconds(LocalDateTime nextExecutionTime) {
+        return nextExecutionTime.atZone(ZoneId.systemDefault()).toEpochSecond()
+                - LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond();
+    }
+
+    public void sendNotification(String topic, String message) {
+        fcmService.sendPushNotification(topic, message);
+    }
+
+    private String pickRandomMessage(AlienConcept concept) {
+        Notification notification = notificationRepository.findRandomMessageByConcept(concept)
                 .orElseThrow(() -> new NotFoundException("해당하는 컨셉의 메시지를 찾을 수 없습니다."));
 
         notification.addSentCount();
 
         return notification.getMessage();
+    }
+
+    private boolean hasSubscribers(NotificationPreference preference, AlienConcept concept) {
+        return userService.hasSubscribers(preference, concept);
+    }
+
+    private String generateTopic(NotificationPreference preference, AlienConcept concept) {
+        return String.join("_",preference.name(), concept.name());
     }
 }

--- a/backend/src/main/java/com/spaceme/user/controller/UserController.java
+++ b/backend/src/main/java/com/spaceme/user/controller/UserController.java
@@ -2,7 +2,7 @@ package com.spaceme.user.controller;
 
 import com.spaceme.auth.domain.Auth;
 import com.spaceme.notification.domain.Device;
-import com.spaceme.user.dto.request.AlienConceptRequest;
+import com.spaceme.user.dto.request.PreferenceRequest;
 import com.spaceme.user.dto.request.SpaceGoalRequest;
 import com.spaceme.user.dto.response.UserResponse;
 import com.spaceme.user.service.UserService;
@@ -40,13 +40,13 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("/me")
+    @PatchMapping("/me")
     public ResponseEntity<Void> updateUserInfo(
             @Auth Long userId,
             @Device String deviceToken,
-            @RequestBody AlienConceptRequest alienConceptRequest
+            @RequestBody PreferenceRequest request
     ) {
-        userService.updateAlienConcept(userId, deviceToken, alienConceptRequest);
+        userService.updateUserPreference(userId, deviceToken, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/spaceme/user/domain/NotificationPreference.java
+++ b/backend/src/main/java/com/spaceme/user/domain/NotificationPreference.java
@@ -9,37 +9,37 @@ import java.util.Arrays;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationPreference {
-    OFF("알림 수신 거부"),
-    HOUR_0("00:00"),
-    HOUR_1("01:00"),
-    HOUR_2("02:00"),
-    HOUR_3("03:00"),
-    HOUR_4("04:00"),
-    HOUR_5("05:00"),
-    HOUR_6("06:00"),
-    HOUR_7("07:00"),
-    HOUR_8("08:00"),
-    HOUR_9("09:00"),
-    HOUR_10("10:00"),
-    HOUR_11("11:00"),
-    HOUR_12("12:00"),
-    HOUR_13("13:00"),
-    HOUR_14("14:00"),
-    HOUR_15("15:00"),
-    HOUR_16("16:00"),
-    HOUR_17("17:00"),
-    HOUR_18("18:00"),
-    HOUR_19("19:00"),
-    HOUR_20("20:00"),
-    HOUR_21("21:00"),
-    HOUR_22("22:00"),
-    HOUR_23("23:00");
+    OFF(-1),
+    HOUR_0(0),
+    HOUR_1(1),
+    HOUR_2(2),
+    HOUR_3(3),
+    HOUR_4(4),
+    HOUR_5(5),
+    HOUR_6(6),
+    HOUR_7(7),
+    HOUR_8(8),
+    HOUR_9(9),
+    HOUR_10(10),
+    HOUR_11(11),
+    HOUR_12(12),
+    HOUR_13(13),
+    HOUR_14(14),
+    HOUR_15(15),
+    HOUR_16(16),
+    HOUR_17(17),
+    HOUR_18(18),
+    HOUR_19(19),
+    HOUR_20(20),
+    HOUR_21(21),
+    HOUR_22(22),
+    HOUR_23(23);
 
-    private final String description;
+    private final int hour;
 
-    public static NotificationPreference from(String preferredHour) {
+    public static NotificationPreference from(int preferredHour) {
         return Arrays.stream(values())
-                .filter(it -> it.description.equals(preferredHour))
+                .filter(it -> it.hour == preferredHour)
                 .findFirst()
                 .orElseThrow(() -> new BadRequestException("알림 수신 희망 시간 설정 과정에서 오류가 발생했습니다."));
     }

--- a/backend/src/main/java/com/spaceme/user/domain/NotificationPreference.java
+++ b/backend/src/main/java/com/spaceme/user/domain/NotificationPreference.java
@@ -1,0 +1,46 @@
+package com.spaceme.user.domain;
+
+import com.spaceme.common.exception.BadRequestException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationPreference {
+    OFF("알림 수신 거부"),
+    HOUR_0("00:00"),
+    HOUR_1("01:00"),
+    HOUR_2("02:00"),
+    HOUR_3("03:00"),
+    HOUR_4("04:00"),
+    HOUR_5("05:00"),
+    HOUR_6("06:00"),
+    HOUR_7("07:00"),
+    HOUR_8("08:00"),
+    HOUR_9("09:00"),
+    HOUR_10("10:00"),
+    HOUR_11("11:00"),
+    HOUR_12("12:00"),
+    HOUR_13("13:00"),
+    HOUR_14("14:00"),
+    HOUR_15("15:00"),
+    HOUR_16("16:00"),
+    HOUR_17("17:00"),
+    HOUR_18("18:00"),
+    HOUR_19("19:00"),
+    HOUR_20("20:00"),
+    HOUR_21("21:00"),
+    HOUR_22("22:00"),
+    HOUR_23("23:00");
+
+    private final String description;
+
+    public static NotificationPreference from(String preferredHour) {
+        return Arrays.stream(values())
+                .filter(it -> it.description.equals(preferredHour))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException("알림 수신 희망 시간 설정 과정에서 오류가 발생했습니다."));
+    }
+}

--- a/backend/src/main/java/com/spaceme/user/domain/User.java
+++ b/backend/src/main/java/com/spaceme/user/domain/User.java
@@ -1,11 +1,8 @@
 package com.spaceme.user.domain;
 
 import com.spaceme.auth.domain.ProviderType;
-import com.spaceme.common.AlienConcept;
 import jakarta.persistence.*;
 import lombok.*;
-
-import static com.spaceme.common.AlienConcept.DEFAULT;
 
 @Entity
 @Getter
@@ -25,22 +22,11 @@ public class User {
 
     private String deviceToken;
 
-    @Setter
-    private String spaceGoal;
-
-    @Enumerated(EnumType.STRING)
-    @Builder.Default
-    private AlienConcept alienConcept = DEFAULT;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ProviderType authType;
 
     public void updateDeviceToken(String deviceToken) {
         this.deviceToken = deviceToken;
-    }
-
-    public void updateAlienConcept(AlienConcept alienConcept) {
-        this.alienConcept = alienConcept;
     }
 }

--- a/backend/src/main/java/com/spaceme/user/domain/UserPreference.java
+++ b/backend/src/main/java/com/spaceme/user/domain/UserPreference.java
@@ -1,0 +1,29 @@
+package com.spaceme.user.domain;
+
+import com.spaceme.common.AlienConcept;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UserPreference {
+    @Id
+    private Long id;
+
+    @MapsId
+    @OneToOne(targetEntity = User.class, fetch = FetchType.LAZY, optional = false)
+    private User user;
+
+    @Setter
+    private String spaceGoal;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private AlienConcept alienConcept = AlienConcept.DEFAULT;
+
+    @Column(nullable = false)
+    private NotificationPreference notificationPreference;
+}

--- a/backend/src/main/java/com/spaceme/user/dto/request/AlienConceptRequest.java
+++ b/backend/src/main/java/com/spaceme/user/dto/request/AlienConceptRequest.java
@@ -1,8 +1,0 @@
-package com.spaceme.user.dto.request;
-
-import com.spaceme.common.AlienConcept;
-
-public record AlienConceptRequest(
-        AlienConcept alienConcept
-) {
-}

--- a/backend/src/main/java/com/spaceme/user/dto/request/PreferenceRequest.java
+++ b/backend/src/main/java/com/spaceme/user/dto/request/PreferenceRequest.java
@@ -1,0 +1,13 @@
+package com.spaceme.user.dto.request;
+
+import com.spaceme.common.AlienConcept;
+import com.spaceme.user.domain.NotificationPreference;
+
+import java.util.Optional;
+
+public record PreferenceRequest(
+        Optional<String> spaceGoal,
+        Optional<AlienConcept> alienConcept,
+        Optional<NotificationPreference> notificationPreference
+) {
+}

--- a/backend/src/main/java/com/spaceme/user/dto/response/UserResponse.java
+++ b/backend/src/main/java/com/spaceme/user/dto/response/UserResponse.java
@@ -4,12 +4,14 @@ import com.spaceme.user.domain.User;
 
 public record UserResponse(
         String nickname,
-        String spaceGoal
+        String spaceGoal,
+        String email
 ) {
-    public static UserResponse from(User user) {
+    public static UserResponse from(User user, String spaceGoal) {
         return new UserResponse(
                 user.getNickname(),
-                user.getSpaceGoal()
+                spaceGoal,
+                user.getEmail()
         );
     }
 }

--- a/backend/src/main/java/com/spaceme/user/repository/UserPreferenceRepository.java
+++ b/backend/src/main/java/com/spaceme/user/repository/UserPreferenceRepository.java
@@ -1,7 +1,10 @@
 package com.spaceme.user.repository;
 
+import com.spaceme.common.AlienConcept;
+import com.spaceme.user.domain.NotificationPreference;
 import com.spaceme.user.domain.UserPreference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+    boolean existsByAlienConceptAndNotificationPreference(AlienConcept concept, NotificationPreference preference);
 }

--- a/backend/src/main/java/com/spaceme/user/repository/UserPreferenceRepository.java
+++ b/backend/src/main/java/com/spaceme/user/repository/UserPreferenceRepository.java
@@ -1,0 +1,7 @@
+package com.spaceme.user.repository;
+
+import com.spaceme.user.domain.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+}

--- a/backend/src/main/java/com/spaceme/user/service/UserService.java
+++ b/backend/src/main/java/com/spaceme/user/service/UserService.java
@@ -92,7 +92,11 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundException("사용자 설정 정보를 찾을 수 없습니다."));
     }
 
-    private String generateTopic(NotificationPreference notificationPreference, AlienConcept alienConcept) {
-        return notificationPreference.name() + alienConcept;
+    private String generateTopic(NotificationPreference preference, AlienConcept concept) {
+        return String.join("_",preference.name(), concept.name());
+    }
+
+    public boolean hasSubscribers(NotificationPreference preference, AlienConcept concept) {
+        return userPreferenceRepository.existsByAlienConceptAndNotificationPreference(concept, preference);
     }
 }


### PR DESCRIPTION
- 사용자 설정 정보 분리
- FCM 구독 토픽에 푸시 알림 희망 시간 추가
- 희망 시간에 따라 동적으로 알림 전송하는 스케줄링 로직 추가

closes #66 